### PR TITLE
Fix duplicate macro causing compilation error

### DIFF
--- a/ntuthesis.cls
+++ b/ntuthesis.cls
@@ -221,8 +221,8 @@
 \newcommand\ntu@date@zh@short[3]{\zhdigits{#1}年\zhnumber{#2}月}
 \newcommand\ntu@date@zh@digit[3]{\the\numexpr#1-1911\relax~年~\number#2~月~\number#3~日}
 \newcommand\ntu@date@zh@digit@short[3]{\the\numexpr#1-1911\relax~年~\number#2~月}
-\newcommand\ntu@date@en@short[3]{\monthname[#2], #1}  % 英文月年之間無逗號
-\newcommand\ntu@date@en@short[3]{\monthname[#2] #1}   % 英文月年之間有逗號
+% 英文日期格式，月份與年份間加入逗號
+\newcommand\ntu@date@en@short[3]{\monthname[#2], #1}
 
 \newcommand{\ntu@setgeometry}[1]{\expandafter\newgeometry\expandafter{#1}}
 


### PR DESCRIPTION
## Summary
- remove duplicate `\ntu@date@en@short` definition in `ntuthesis.cls`
- keep single definition with comma between month and year

## Testing
- `latexmk -xelatex main.tex` *(fails: Missing character warnings, but build succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_6867a0f956d8832bbbc23e2de45793d7